### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# Sphinx documentation
+docs/_build/
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyCharm
+.idea/
+
+# Visual Studio Code
+.vscode/
+
+# Visual Studio
+.vs/


### PR DESCRIPTION
Added ignoring for
- IDE (vs, vscode and idea)
- pycache
- venv
- Sphinx docs builds (not used at the moment)